### PR TITLE
resolves circular __repr__ in Pair and MultiQubit

### DIFF
--- a/src/requsim/quantum_objects/multi_qubit.py
+++ b/src/requsim/quantum_objects/multi_qubit.py
@@ -38,9 +38,13 @@ class MultiQubit(WorldObject):
         super(MultiQubit, self).__init__(world=world, label=label)
 
     def __repr__(self):
-        return self.__class__.__name__ + (
-            f"(world={self.world}, qubits={self._qubits}, "
-            f"initial_state={self.state}, label={self.label})"
+        return (
+            f'<{self.__class__.__module__}.{self.__class__.__name__} "{self.label}" '
+            + "qubits=["
+            + ", ".join([x.label for x in self.qubits])
+            + "]"
+            + f" with state at last update {self.state}"
+            + ">"
         )
 
     def __str__(self):

--- a/src/requsim/quantum_objects/pair.py
+++ b/src/requsim/quantum_objects/pair.py
@@ -44,9 +44,13 @@ class Pair(WorldObject):
         super(Pair, self).__init__(world=world, label=label)
 
     def __repr__(self):
-        return self.__class__.__name__ + (
-            f"(world={self.world}, qubits={self.qubits}, "
-            f"initial_state={self.state}, label={self.label})"
+        return (
+            f'<{self.__class__.__module__}.{self.__class__.__name__} "{self.label}" '
+            + "qubits=["
+            + ", ".join([x.label for x in self.qubits])
+            + "]"
+            + f" with state at last update {self.state}"
+            + ">"
         )
 
     def __str__(self):

--- a/src/requsim/quantum_objects/qubit.py
+++ b/src/requsim/quantum_objects/qubit.py
@@ -46,7 +46,7 @@ class Qubit(WorldObject):
     def __repr__(self):
         return self.__class__.__name__ + (
             f"(world={self.world}, unresolved_noises={self._unresolved_noises}, "
-            f"info={self._info}, label={self.label})"
+            f"info={dict(self._info)}, label={self.label})"
         )
 
     def __str__(self):


### PR DESCRIPTION
the previous `__repr__` in Pair and MultiQubit was not eval-able anyway because the state attribute only makes sense at the time of the last update anyway.